### PR TITLE
Add Mouse Polling Rate Test to Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@
 
 * [**EarTrumpet**](https://eartrumpet.app/) – Software to help Users better manage the Controls of their Computer's Volume.
 
+* [**Mouse Polling Rate Test**](https://mousepollingratetest.com/) – Free browser-based tool to test mouse & keyboard polling rate, CPS, reaction time, and accuracy. No install required.
+
+
 **[`^        Back to Contents        ^`](#table-of-contents)**
 </br>
 </br>


### PR DESCRIPTION
## Addition

Add [Mouse Polling Rate Test](https://mousepollingratetest.com/) to the Controls section.

A free, browser-based tool for gamers to measure:
- Mouse & keyboard polling rate (125Hz to 8000Hz)
- CPS (clicks per second)
- Reaction time
- Mouse accuracy

No installation needed, works directly in the browser.