### PR TITLE
Add Deep Rock Galactic Hazard Bonus Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@
 
 * [**Geek Uninstaller**](https://geekuninstaller.com/) – Clean Removal Performs deep and fast scanning and removes all Leftovers.
 
+* [**Deep Rock Galactic Hazard Bonus Calculator**](https://smart-calculators.net/en-US/tools/deep-rock-galactic-hazard-bonus-calculator) - Set your Hazard level, modifiers, cave and warnings to get the exact reward multiplier and post-bonus Credits, Crafting Minerals and XP.
+
 **[`^        Back to Contents        ^`](#table-of-contents)**
 </br>
 </br>


### PR DESCRIPTION
Added a community-built calculator for Deep Rock Galactic's Hazard Bonus mechanic. The tool sets Hazard level, cave modifiers, and warnings to compute the reward multiplier (+25% to +265%) and shows the post-bonus Credits, Crafting Minerals and XP earned on a mission.

We built this because the wiki publishes the component tables but leaves the adding-up to players - no calculator existed for this specific mechanic. Data source: official Deep Rock Galactic wiki (deeprockgalactic.wiki.gg), verified 2026-07-03.

Following the repo's no-complex-review-process ethos, this is a one-line entry following your existing Various Tools format.